### PR TITLE
Align with environments repo

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -23,7 +23,7 @@ locals {
     }
   }
 
-  # remove nulls so merge() doesn't include them
+  # remove nulls so merge() doesn't include them
   ebs_volumes_without_nulls = {
     for key1, value1 in var.ebs_volumes :
     key1 => {
@@ -48,7 +48,7 @@ locals {
     } if contains(keys(var.ebs_volume_config), lookup(value, "label", "-"))
   }
 
-  # Auto calculate swap volume size based on instance memory size
+  # Auto calculate swap volume size based on instance memory size
   ebs_volumes_swap_size = data.aws_ec2_instance_type.this.memory_size >= 16384 ? 16 : (data.aws_ec2_instance_type.this.memory_size / 1024)
   ebs_volumes_swap = {
     for key, value in local.ebs_volumes_without_nulls :
@@ -57,7 +57,7 @@ locals {
     } if lookup(value, "label", null) == "swap"
   }
 
-  # remove nulls so merge() doesn't include them
+  # remove nulls so merge() doesn't include them
   ebs_volumes_from_config_without_nulls = {
     for key1, value1 in local.ebs_volumes_from_config :
     key1 => {

--- a/main.tf
+++ b/main.tf
@@ -15,15 +15,19 @@ resource "aws_launch_template" "this" {
       device_name  = block_device_mappings.key
       no_device    = lookup(block_device_mappings.value, "no_device", null)
       virtual_name = lookup(block_device_mappings.value, "virtual_name", null)
-      ebs {
-        delete_on_termination = block_device_mappings.value.type != null ? true : null
-        encrypted             = block_device_mappings.value.type != null ? true : null
 
-        kms_key_id  = try(block_device_mappings.value.kms_key_id, var.ebs_kms_key_id)
-        iops        = try(block_device_mappings.value.iops > 0, false) ? block_device_mappings.value.iops : null
-        throughput  = try(block_device_mappings.value.throughput > 0, false) ? block_device_mappings.value.throughput : null
-        volume_size = block_device_mappings.value.size
-        volume_type = block_device_mappings.value.type
+      dynamic "ebs" {
+        for_each = lookup(block_device_mappings.value, "no_device", null) != true ? [block_device_mappings.value] : []
+        content {
+          delete_on_termination = ebs.value.type != null ? true : null
+          encrypted             = ebs.value.type != null ? true : null
+
+          kms_key_id  = try(ebs.value.kms_key_id, var.ebs_kms_key_id)
+          iops        = try(ebs.value.iops > 0, false) ? ebs.value.iops : null
+          throughput  = try(ebs.value.throughput > 0, false) ? ebs.value.throughput : null
+          volume_size = ebs.value.size
+          volume_type = ebs.value.type
+        }
       }
     }
   }
@@ -47,6 +51,14 @@ resource "aws_launch_template" "this" {
     associate_public_ip_address = false
     security_groups             = var.instance.vpc_security_group_ids
     delete_on_termination       = true
+  }
+
+  dynamic "placement" {
+    for_each = var.availability_zone != null ? [var.availability_zone] : []
+
+    content {
+      availability_zone = placement.value
+    }
   }
 
   dynamic "private_dns_name_options" {
@@ -299,7 +311,7 @@ resource "aws_lb_target_group" "this" {
 resource "aws_cloudwatch_metric_alarm" "this" {
   for_each = var.cloudwatch_metric_alarms
 
-  alarm_name          = each.key
+  alarm_name          = "${aws_autoscaling_group.this.name}-${each.key}"
   comparison_operator = each.value.comparison_operator
   evaluation_periods  = each.value.evaluation_periods
   metric_name         = each.value.metric_name
@@ -314,5 +326,7 @@ resource "aws_cloudwatch_metric_alarm" "this" {
   dimensions = merge(each.value.dimensions, {
     "AutoScalingGroupName" = aws_autoscaling_group.this.name
   })
-  tags = {}
+  tags = merge(var.tags, {
+    Name = "${aws_autoscaling_group.this.name}-${each.key}"
+  })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "name" {
   description = "Provide a unique name for the auto scale group"
 }
 
+variable "availability_zone" {
+  type        = string
+  description = "Optionally associated the ASG with a single availability zone"
+  default     = null
+}
+
 variable "instance" {
   description = "EC2 launch template / instance settings, see aws_instance documentation"
   type = object({
@@ -124,6 +130,7 @@ variable "ebs_volumes" {
     size        = optional(number)
     type        = optional(string)
     kms_key_id  = optional(string)
+    no_device   = optional(bool)
   }))
 }
 
@@ -230,7 +237,7 @@ variable "lb_target_groups" {
 }
 
 variable "cloudwatch_metric_alarms" {
-  description = "Map of cloudwatch metric alarms."
+  description = "Map of cloudwatch metric alarms.  The alarm name is set to the autoscaling group name plus the map key."
   type = map(object({
     comparison_operator = string
     evaluation_periods  = number
@@ -245,7 +252,6 @@ variable "cloudwatch_metric_alarms" {
     datapoints_to_alarm = optional(number)
     treat_missing_data  = optional(string, "missing")
     dimensions          = optional(map(string), {})
-    tags                = optional(map(string))
   }))
   default = {}
 }


### PR DESCRIPTION
Just updating the module to align with changes that have been added into environments module.  I'll zap the environments module version after this to ensure we don't have two versions of same thing.  Changes:
- fix to cloudwatch alarms
- whitespace (nbsp chars)
- allow for block_device_mappings with no devices
- add availability_zone option.