### PR TITLE
DSOS-1987: allow specific tags for ec2 and ebs resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "aws_launch_template" "this" {
 
   tag_specifications {
     resource_type = "instance"
-    tags = merge(local.tags, {
+    tags = merge(local.tags, var.instance.tags, {
       Name = var.name
     })
   }
@@ -82,7 +82,7 @@ resource "aws_launch_template" "this" {
   # all volumes will get tagged with the same name
   tag_specifications {
     resource_type = "volume"
-    tags = merge(local.tags, {
+    tags = merge(local.tags, var.ebs_volume_tags, {
       Name = "${var.name}-volume"
     })
   }

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "subnet_ids" {
 
 variable "tags" {
   type        = map(any)
-  description = "Default tags to be applied to resources"
+  description = "Default tags to be applied to resources.  Additional tags can be added to EBS volumes or EC2s, see instance and ebs_volume_tags variables."
 }
 
 variable "account_ids_lookup" {
@@ -74,6 +74,7 @@ variable "instance" {
       enable_resource_name_dns_a_record    = optional(bool)
       hostname_type                        = string
     }))
+    tags = optional(map(string), {})
   })
 }
 
@@ -132,6 +133,12 @@ variable "ebs_volumes" {
     kms_key_id  = optional(string)
     no_device   = optional(bool)
   }))
+}
+
+variable "ebs_volume_tags" {
+  description = "Additional tags to apply to ebs volumes"
+  type        = map(string)
+  default     = {}
 }
 
 variable "iam_resource_names_prefix" {


### PR DESCRIPTION
Finer control over tagging.  Allow additional tags specific to ec2_instance and ebs_volume resources.   This allows us to add a backup tag to only the ec2 instance resources, thus avoiding duplicate ec2 and ebs backups.  Tested in nomis accounts. 