### PR TITLE
DSOS-2406: align secretsmanager options with ssm

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -23,9 +23,7 @@ locals {
   }
   ssm_parameters_default = {
     for key, value in var.ssm_parameters != null ? var.ssm_parameters : {} :
-    key => merge(value, {
-      value = "placeholder, overwrite me outside of terraform"
-    }) if value.value == null && value.random == null
+    key => value if value.value == null && value.random == null
   }
 
   secretsmanager_random_passwords = {

--- a/locals.tf
+++ b/locals.tf
@@ -23,7 +23,9 @@ locals {
   }
   ssm_parameters_default = {
     for key, value in var.ssm_parameters != null ? var.ssm_parameters : {} :
-    key => value if value.value == null && value.random == null
+    key => merge(value, {
+      value = "placeholder, overwrite me outside of terraform"
+    }) if value.value == null && value.random == null
   }
 
   secretsmanager_random_passwords = {
@@ -42,9 +44,7 @@ locals {
   }
   secretsmanager_secrets_default = {
     for key, value in var.secretsmanager_secrets != null ? var.secretsmanager_secrets : {} :
-    key => merge(value, {
-      value = "placeholder, overwrite me outside of terraform"
-    }) if value.value == null && value.random == null
+    key => value if value.value == null && value.random == null
   }
 
   ami_block_device_mappings = {

--- a/locals.tf
+++ b/locals.tf
@@ -28,6 +28,27 @@ locals {
     }) if value.value == null && value.random == null
   }
 
+  secretsmanager_random_passwords = {
+    for key, value in var.secretsmanager_secrets != null ? var.secretsmanager_secrets : {} :
+    key => value.random if value.random != null
+  }
+  secretsmanager_secrets_value = {
+    for key, value in var.secretsmanager_secrets != null ? var.secretsmanager_secrets : {} :
+    key => value if value.value != null
+  }
+  secretsmanager_secrets_random = {
+    for key, value in var.secretsmanager_secrets != null ? var.secretsmanager_secrets : {} :
+    key => merge(value, {
+      value = random_password.secrets[key].result
+    }) if value.value == null && value.random != null
+  }
+  secretsmanager_secrets_default = {
+    for key, value in var.secretsmanager_secrets != null ? var.secretsmanager_secrets : {} :
+    key => merge(value, {
+      value = "placeholder, overwrite me outside of terraform"
+    }) if value.value == null && value.random == null
+  }
+
   ami_block_device_mappings = {
     for bdm in data.aws_ami.this.block_device_mappings : bdm.device_name => bdm
   }

--- a/main.tf
+++ b/main.tf
@@ -278,17 +278,6 @@ resource "aws_secretsmanager_secret_version" "fixed" {
   secret_string = each.value.value
 }
 
-resource "aws_secretsmanager_secret_version" "placeholder" {
-  for_each = local.secretsmanager_secrets_default
-
-  secret_id     = aws_secretsmanager_secret.placeholder[each.key].id
-  secret_string = each.value.value
-
-  lifecycle {
-    ignore_changes = [secret_string]
-  }
-}
-
 resource "aws_iam_role" "this" {
   name                 = "${var.iam_resource_names_prefix}-role-${var.name}"
   path                 = "/"

--- a/main.tf
+++ b/main.tf
@@ -228,19 +228,65 @@ resource "aws_ssm_parameter" "placeholder" {
   }
 }
 
-resource "aws_secretsmanager_secret" "placeholder" {
-  # skipped check to keep consistent behaviour between ssm params and secrets
-  # Rotation can be added later as a configurable option. Some will want it, for some it will break things
-  #checkov:skip=CKV2_AWS_57: Ensure Secrets Manager secrets should have automatic rotation enabled
-  for_each = var.secretsmanager_secrets
+resource "random_password" "secrets" {
+  for_each = local.secretsmanager_random_passwords
 
-  name        = "/${var.secretsmanager_secrets_prefix}${var.name}/${each.key}"
-  description = each.value.description
-  kms_key_id  = each.value.kms_key_id
+  length  = each.value.length
+  special = each.value.special
+}
+
+resource "aws_secretsmanager_secret" "fixed" {
+  # skipped check as the secret value is defined by terraform so cannot be rotated by AWS
+  #checkov:skip=CKV2_AWS_57: Ensure Secrets Manager secrets should have automatic rotation enabled
+  for_each = merge(
+    local.secretsmanager_secrets_value,
+    local.secretsmanager_secrets_random,
+  )
+
+  name                    = "/${var.secretsmanager_secrets_prefix}${var.name}/${each.key}"
+  description             = each.value.description
+  kms_key_id              = each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
+  recovery_window_in_days = each.value.recovery_window_in_days
 
   tags = merge(local.tags, {
     Name = "${var.name}-${each.key}"
   })
+}
+
+resource "aws_secretsmanager_secret" "placeholder" {
+  # Rotation can be added later as a configurable option
+  #checkov:skip=CKV2_AWS_57: Ensure Secrets Manager secrets should have automatic rotation enabled
+  for_each = local.secretsmanager_secrets_default
+
+  name                    = "/${var.secretsmanager_secrets_prefix}${var.name}/${each.key}"
+  description             = each.value.description
+  kms_key_id              = each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
+  recovery_window_in_days = each.value.recovery_window_in_days
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-${each.key}"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "fixed" {
+  for_each = merge(
+    local.secretsmanager_secrets_value,
+    local.secretsmanager_secrets_random,
+  )
+
+  secret_id     = aws_secretsmanager_secret.fixed[each.key].id
+  secret_string = each.value.value
+}
+
+resource "aws_secretsmanager_secret_version" "placeholder" {
+  for_each = local.secretsmanager_secrets_default
+
+  secret_id     = aws_secretsmanager_secret.placeholder[each.key].id
+  secret_string = each.value.value
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
 }
 
 resource "aws_iam_role" "this" {

--- a/main.tf
+++ b/main.tf
@@ -245,7 +245,7 @@ resource "aws_secretsmanager_secret" "fixed" {
 
   name                    = "/${var.secretsmanager_secrets_prefix}${var.name}/${each.key}"
   description             = each.value.description
-  kms_key_id              = each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
+  kms_key_id              = each.value.kms_key_id
   recovery_window_in_days = each.value.recovery_window_in_days
 
   tags = merge(local.tags, {
@@ -260,7 +260,7 @@ resource "aws_secretsmanager_secret" "placeholder" {
 
   name                    = "/${var.secretsmanager_secrets_prefix}${var.name}/${each.key}"
   description             = each.value.description
-  kms_key_id              = each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
+  kms_key_id              = each.value.kms_key_id
   recovery_window_in_days = each.value.recovery_window_in_days
 
   tags = merge(local.tags, {

--- a/main.tf
+++ b/main.tf
@@ -253,6 +253,16 @@ resource "aws_secretsmanager_secret" "fixed" {
   })
 }
 
+resource "aws_secretsmanager_secret_version" "fixed" {
+  for_each = merge(
+    local.secretsmanager_secrets_value,
+    local.secretsmanager_secrets_random,
+  )
+
+  secret_id     = aws_secretsmanager_secret.fixed[each.key].id
+  secret_string = each.value.value
+}
+
 resource "aws_secretsmanager_secret" "placeholder" {
   # Rotation can be added later as a configurable option
   #checkov:skip=CKV2_AWS_57: Ensure Secrets Manager secrets should have automatic rotation enabled
@@ -266,16 +276,6 @@ resource "aws_secretsmanager_secret" "placeholder" {
   tags = merge(local.tags, {
     Name = "${var.name}-${each.key}"
   })
-}
-
-resource "aws_secretsmanager_secret_version" "fixed" {
-  for_each = merge(
-    local.secretsmanager_secrets_value,
-    local.secretsmanager_secrets_random,
-  )
-
-  secret_id     = aws_secretsmanager_secret.fixed[each.key].id
-  secret_string = each.value.value
 }
 
 resource "aws_iam_role" "this" {

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -15,6 +15,8 @@ module "ec2_test_autoscaling_group" {
   ebs_volumes_copy_all_from_ami = try(each.value.ebs_volumes_copy_all_from_ami, true)
   ebs_volume_config             = lookup(each.value, "ebs_volume_config", {})
   ebs_volumes                   = lookup(each.value, "ebs_volumes", {})
+  secretsmanager_secrets_prefix = lookup(each.value, "secretsmanager_secrets_prefix", "test/")
+  secretsmanager_secrets        = lookup(each.value, "secretsmanager_secrets", null)
   ssm_parameters_prefix         = lookup(each.value, "ssm_parameters_prefix", "test/")
   ssm_parameters                = lookup(each.value, "ssm_parameters", null)
   autoscaling_group             = merge(local.ec2_test.autoscaling_group, lookup(each.value, "autoscaling_group", {}))

--- a/variables.tf
+++ b/variables.tf
@@ -222,12 +222,18 @@ variable "ssm_parameters" {
 }
 
 variable "secretsmanager_secrets" {
-  description = "A map of secretsmanager secrets to create. No value is created, add a value outside of terraform"
+  description = "A map of secretsmanager secrets to create. Set a specific value or a randomly generated value.  If neither random or value are set, a placeholder value is created which can be updated outside of terraform"
   type = map(object({
-    description = optional(string)
-    kms_key_id  = optional(string)
+    description             = optional(string)
+    kms_key_id              = optional(string)
+    recovery_window_in_days = optional(number)
+    random = optional(object({
+      length  = number
+      special = optional(bool)
+    }))
+    value = optional(string)
   }))
-  default = {}
+  default = null
 }
 
 variable "lb_target_groups" {


### PR DESCRIPTION
Add additional option to create SecretsManager secrets with fixed or random value, and allow recovery_window_in_days to be set. This brings it in line with equivalent SSM parameter option.
Tested in nomis.