### PR TITLE
DSOS-2590: allow healthcheck protocol specify and remove unused variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -385,6 +385,7 @@ resource "aws_lb_target_group" "this" {
       matcher             = health_check.value.matcher
       path                = health_check.value.path
       port                = health_check.value.port
+      protocol            = health_check.value.protocol
       timeout             = health_check.value.timeout
       unhealthy_threshold = health_check.value.unhealthy_threshold
     }

--- a/variables.tf
+++ b/variables.tf
@@ -241,7 +241,6 @@ variable "lb_target_groups" {
   type = map(object({
     port                 = optional(number)
     protocol             = optional(string)
-    target_type          = string
     deregistration_delay = optional(number)
     health_check = optional(object({
       enabled             = optional(bool)
@@ -250,6 +249,7 @@ variable "lb_target_groups" {
       matcher             = optional(string)
       path                = optional(string)
       port                = optional(number)
+      protocol            = optional(string)
       timeout             = optional(number)
       unhealthy_threshold = optional(number)
     }))


### PR DESCRIPTION
This change is a fix to the LB target groups - allows healthcheck protocol to be specified. This currently defaults to http but sometimes https is required.
Also removed an unused variable.

I've done a sweep of environments repo and this is only used by DSO and delius-iaps,, and delius doesn't use this functionality, so won't be impacting to anybody else.

Tested in DSO applications against this branch