### PR TITLE
DSOS-2838: instance refresh fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ resource "aws_autoscaling_group" "this" {
 
   launch_template {
     id      = aws_launch_template.this.id
-    version = "$Default"
+    version = aws_launch_template.this.latest_version
   }
 
   dynamic "initial_lifecycle_hook" {


### PR DESCRIPTION
You can't enable instance refresh if the launch template is set to $Default.  Needs to be set to latest version as per AWS docs.
Regresssion tested in nomis-test (didn't break anything)
Instance refresh now working with this change in nomis-preproduction