### PR TITLE
feature 7412 - added AmazonSSMManagedInstanceCore policy to module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -298,7 +298,7 @@ resource "aws_iam_role" "this" {
     }
   )
 
-  managed_policy_arns = var.instance_profile_policies
+managed_policy_arns = concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies)
 
   tags = merge(local.tags, {
     Name = "${var.iam_resource_names_prefix}-role-${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -298,7 +298,7 @@ resource "aws_iam_role" "this" {
     }
   )
 
-managed_policy_arns = concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies)
+  managed_policy_arns = concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies)
 
   tags = merge(local.tags, {
     Name = "${var.iam_resource_names_prefix}-role-${var.name}"


### PR DESCRIPTION
## A reference to the issue / Description of it

[#7412](https://github.com/ministryofjustice/modernisation-platform/issues/7412)

## How does this PR fix the problem?

PR adds the SSM policy as a default when an instance is created through the module

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Tested by calling the module with instances that both have the policy already and instances instances that do not have the policy and the change did not break.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No