### PR TITLE
add managed policy exclusivity, replace deprecated `manged_policy_arn` value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -298,11 +298,18 @@ resource "aws_iam_role" "this" {
     }
   )
 
-  managed_policy_arns = concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies)
-
   tags = merge(local.tags, {
     Name = "${var.iam_resource_names_prefix}-role-${var.name}"
   })
+}
+
+# exclusive policy attachment for managed policies
+resource "aws_iam_role_policy_attachments_exclusive" "this" {
+  role_name = aws_iam_role.this.name
+  policy_arns = concat(
+    ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"],
+    var.instance_profile_policies
+  )
 }
 
 data "aws_iam_policy_document" "ssm_params_and_secrets" {


### PR DESCRIPTION
We get persistent warnings that `managed_policy_arn` is deprecated. 

Replace this with resource [aws_iam_role_policy_attachments_exclusive] (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) in response to deployment warnings: 

```
│ Warning: Argument is deprecated
│ 
│   with module.baseline.module.ec2_instance["t1-ncr-db-1-a"].aws_iam_role.this,
│   on .terraform/modules/baseline.ec2_instance/main.tf line 343, in resource "aws_iam_role" "this":
│  343:   managed_policy_arns = var.instance_profile_policies
│ 
│ The managed_policy_arns argument is deprecated. Use the
│ aws_iam_role_policy_attachment resource instead. If Terraform should
│ exclusively manage all managed policy attachments (the current behavior of
│ this argument), use the aws_iam_role_policy_attachments_exclusive resource
│ as well.
```
Using the 'exclusive' variant of this resource as it says that's the current behavior of managed_policy_arn that's being replaced.



