### PR TITLE
Adding opt out for SSM policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -305,10 +305,9 @@ resource "aws_iam_role" "this" {
 
 # IAM role policy attachment
 resource "aws_iam_role_policy_attachment" "this" {
-  count = var.skip_iam_role_policy_attachment ? length(var.instance_profile_policies) : length(var.instance_profile_policies) + 1
-  role  = aws_iam_role.this.name
-
-  policy_arn = var.skip_iam_role_policy_attachment && count.index == 0 ? var.instance_profile_policies[count.index] : element(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies), count.index)
+  count      = var.skip_iam_role_policy_attachment ? 0 : length(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies))
+  role       = aws_iam_role.this.name
+  policy_arn = element(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies), count.index)
 }
 
 data "aws_iam_policy_document" "ssm_params_and_secrets" {

--- a/main.tf
+++ b/main.tf
@@ -305,9 +305,9 @@ resource "aws_iam_role" "this" {
 
 # IAM role policy attachment
 resource "aws_iam_role_policy_attachment" "this" {
-  count      = var.skip_iam_role_policy_attachment ? 0 : length(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies))
+  count      = var.skip_iam_role_policy_attachment ? length(var.instance_profile_policies) : length(concat([var.default_policy_arn], var.instance_profile_policies))
   role       = aws_iam_role.this.name
-  policy_arn = element(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies), count.index)
+  policy_arn = var.skip_iam_role_policy_attachment ? element(var.instance_profile_policies, count.index) : element(concat([var.default_policy_arn], var.instance_profile_policies), count.index)
 }
 
 data "aws_iam_policy_document" "ssm_params_and_secrets" {

--- a/main.tf
+++ b/main.tf
@@ -305,9 +305,10 @@ resource "aws_iam_role" "this" {
 
 # IAM role policy attachment
 resource "aws_iam_role_policy_attachment" "this" {
-  count      = length(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies))
-  role       = aws_iam_role.this.name
-  policy_arn = element(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies), count.index)
+  count = var.skip_iam_role_policy_attachment ? length(var.instance_profile_policies) : length(var.instance_profile_policies) + 1
+  role  = aws_iam_role.this.name
+
+  policy_arn = var.skip_iam_role_policy_attachment && count.index == 0 ? var.instance_profile_policies[count.index] : element(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies), count.index)
 }
 
 data "aws_iam_policy_document" "ssm_params_and_secrets" {

--- a/test/unit-test/locals.tf
+++ b/test/unit-test/locals.tf
@@ -10,8 +10,9 @@ locals {
 
   # create list of common managed policies that can be attached to ec2 instance profiles
   ec2_common_managed_policies = [
-    aws_iam_policy.ec2_test_common_policy.arn
+    aws_iam_policy.ec2_test_common_policy.arn,
   ]
+
 
   tags = {
     component = "test"

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -18,7 +18,7 @@ module "ec2_test_autoscaling_group" {
   secretsmanager_secrets_prefix   = lookup(each.value, "secretsmanager_secrets_prefix", "test/")
   secretsmanager_secrets          = lookup(each.value, "secretsmanager_secrets", null)
   ssm_parameters_prefix           = lookup(each.value, "ssm_parameters_prefix", "test/")
-  skip_iam_role_policy_attachment = true
+  skip_iam_role_policy_attachment = false
   ssm_parameters                  = lookup(each.value, "ssm_parameters", null)
   autoscaling_group               = merge(local.ec2_test.autoscaling_group, lookup(each.value, "autoscaling_group", {}))
   autoscaling_schedules           = lookup(each.value, "autoscaling_schedules", local.autoscaling_schedules_default)

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -18,6 +18,7 @@ module "ec2_test_autoscaling_group" {
   secretsmanager_secrets_prefix = lookup(each.value, "secretsmanager_secrets_prefix", "test/")
   secretsmanager_secrets        = lookup(each.value, "secretsmanager_secrets", null)
   ssm_parameters_prefix         = lookup(each.value, "ssm_parameters_prefix", "test/")
+  skip_iam_role_policy_attachment = true
   ssm_parameters                = lookup(each.value, "ssm_parameters", null)
   autoscaling_group             = merge(local.ec2_test.autoscaling_group, lookup(each.value, "autoscaling_group", {}))
   autoscaling_schedules         = lookup(each.value, "autoscaling_schedules", local.autoscaling_schedules_default)

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -9,25 +9,25 @@ module "ec2_test_autoscaling_group" {
 
   name = each.key
 
-  ami_name                      = each.value.ami_name
-  ami_owner                     = try(each.value.ami_owner, "core-shared-services-production")
-  instance                      = merge(local.ec2_test.instance, lookup(each.value, "instance", {}))
-  ebs_volumes_copy_all_from_ami = try(each.value.ebs_volumes_copy_all_from_ami, true)
-  ebs_volume_config             = lookup(each.value, "ebs_volume_config", {})
-  ebs_volumes                   = lookup(each.value, "ebs_volumes", {})
-  secretsmanager_secrets_prefix = lookup(each.value, "secretsmanager_secrets_prefix", "test/")
-  secretsmanager_secrets        = lookup(each.value, "secretsmanager_secrets", null)
-  ssm_parameters_prefix         = lookup(each.value, "ssm_parameters_prefix", "test/")
+  ami_name                        = each.value.ami_name
+  ami_owner                       = try(each.value.ami_owner, "core-shared-services-production")
+  instance                        = merge(local.ec2_test.instance, lookup(each.value, "instance", {}))
+  ebs_volumes_copy_all_from_ami   = try(each.value.ebs_volumes_copy_all_from_ami, true)
+  ebs_volume_config               = lookup(each.value, "ebs_volume_config", {})
+  ebs_volumes                     = lookup(each.value, "ebs_volumes", {})
+  secretsmanager_secrets_prefix   = lookup(each.value, "secretsmanager_secrets_prefix", "test/")
+  secretsmanager_secrets          = lookup(each.value, "secretsmanager_secrets", null)
+  ssm_parameters_prefix           = lookup(each.value, "ssm_parameters_prefix", "test/")
   skip_iam_role_policy_attachment = true
-  ssm_parameters                = lookup(each.value, "ssm_parameters", null)
-  autoscaling_group             = merge(local.ec2_test.autoscaling_group, lookup(each.value, "autoscaling_group", {}))
-  autoscaling_schedules         = lookup(each.value, "autoscaling_schedules", local.autoscaling_schedules_default)
-  iam_resource_names_prefix     = "ec2-test-asg"
-  instance_profile_policies     = local.ec2_common_managed_policies
-  application_name              = local.application_name
-  region                        = local.region
-  subnet_ids                    = [data.aws_subnet.private_subnets_a.id]
-  tags                          = merge(local.tags, local.ec2_test.tags, try(each.value.tags, {}))
-  account_ids_lookup            = local.environment_management.account_ids
-  cloudwatch_metric_alarms      = {}
+  ssm_parameters                  = lookup(each.value, "ssm_parameters", null)
+  autoscaling_group               = merge(local.ec2_test.autoscaling_group, lookup(each.value, "autoscaling_group", {}))
+  autoscaling_schedules           = lookup(each.value, "autoscaling_schedules", local.autoscaling_schedules_default)
+  iam_resource_names_prefix       = "ec2-test-asg"
+  instance_profile_policies       = local.ec2_common_managed_policies
+  application_name                = local.application_name
+  region                          = local.region
+  subnet_ids                      = [data.aws_subnet.private_subnets_a.id]
+  tags                            = merge(local.tags, local.ec2_test.tags, try(each.value.tags, {}))
+  account_ids_lookup              = local.environment_management.account_ids
+  cloudwatch_metric_alarms        = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,11 @@ variable "vpc_id" {
   default     = null
 }
 
+variable "skip_iam_role_policy_attachment" {
+  description = "If true, skip the IAM role policy attachment"
+  type        = bool
+  default     = false
+}
 variable "subnet_ids" {
   type        = list(string)
   description = "List of subnet ids given to the ASG to set the associated AZs (and therefore redundancy of the ASG instances)"

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,12 @@ variable "skip_iam_role_policy_attachment" {
   type        = bool
   default     = false
 }
+
+variable "default_policy_arn" {
+  description = "Default policy ARN to attach"
+  type        = string
+  default     = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
 variable "subnet_ids" {
   type        = list(string)
   description = "List of subnet ids given to the ASG to set the associated AZs (and therefore redundancy of the ASG instances)"


### PR DESCRIPTION
As part of issue Re-visit how we apply the AmazonSSMManagedInstanceCore in the ec2-instance and ec2-autoscaling-group modules
[#8969](https://github.com/ministryofjustice/modernisation-platform/issues/8969)

i have added in a switch that give you the ability to omit the ssm policy