### PR TITLE
Add Session Manager log permissions to EC2 roles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -314,6 +314,30 @@ resource "aws_iam_role_policy_attachment" "this" {
   policy_arn = each.value
 }
 
+data "aws_iam_policy_document" "session_manager_cloudwatch_logs" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:session-manager-logs",
+      "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:session-manager-logs:log-stream:*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "session_manager_cloudwatch_logs" {
+  name   = "SessionManagerCloudWatchLogs"
+  role   = aws_iam_role.this.id
+  policy = data.aws_iam_policy_document.session_manager_cloudwatch_logs.json
+}
+
 data "aws_iam_policy_document" "ssm_params_and_secrets" {
   count = var.ssm_parameters != null || var.secretsmanager_secrets != null ? 1 : 0
   dynamic "statement" {


### PR DESCRIPTION
## A reference to the issue / Description of it

Allows EC2 instances created by this module to write AWS Systems Manager Session Manager transcript logs to the central `session-manager-logs` CloudWatch log group that's been rolled out via baselines.

## How does this PR fix the problem?

Adds an inline IAM policy to the EC2 instance role with the CloudWatch Logs permissions required by Session Manager transcript logging: create log streams, describe log groups/streams, and put log events.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

{Please write here}

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [ ] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
